### PR TITLE
Add monitoring label to promtail service + set limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enable sli monitoring and metric scraping
+- Set deployment resources (Requests/Limits)
 
 ## [0.2.1] - 2021-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable metric scraping
+
 ## [0.2.1] - 2021-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enable metric scraping
+- Enable sli monitoring and metric scraping
 
 ## [0.2.1] - 2021-06-14
 

--- a/helm/promtail/templates/daemonset.yaml
+++ b/helm/promtail/templates/daemonset.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "promtail.fullname" . }}
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
+    giantswarm.io/service-type: "managed"
+    giantswarm.io/monitoring_basic_sli: "true"
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/promtail/templates/service-metrics.yaml
+++ b/helm/promtail/templates/service-metrics.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "promtail.fullname" . }}-metrics
   labels:
     {{- include "promtail.labels" . | nindent 4 }}
+    giantswarm.io/monitoring: "true"
 spec:
   clusterIP: None
   ports:
@@ -14,4 +14,3 @@ spec:
       protocol: TCP
   selector:
     {{- include "promtail.selectorLabels" . | nindent 4 }}
-{{- end }}

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -65,13 +65,13 @@ readinessProbe:
   timeoutSeconds: 1
 
 # -- Resource requests and limits
-resources: {}
-#  limits:
-#    cpu: 200m
-#    memory: 128Mi
-#  requests:
-#    cpu: 100m
-#    memory: 128Mi
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 # -- The security context for pods
 podSecurityContext:


### PR DESCRIPTION
This PR adds giant swarm monitoring labels to the promtail deployment
and enables limits/requests