### PR TITLE
Add monitoring label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Modified
+
+- Added 
+
 ## [0.4.1] - 2022-07-06
 
 ### Modified

--- a/helm/promtail/templates/service.yaml
+++ b/helm/promtail/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "promtail.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "promtail.selectorLabels" . | nindent 8 }}
+    {{- with .Values.serviceLabels }}
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+spec:
+  selector:
+    {{- include "promtail.selectorLabels" $ | nindent 4 }}
+  clusterIP: "None"
+  ports:
+    - protocol: TCP
+      port: 9091
+      targetPort: {{ .Values.config.serverPort }}

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -39,7 +39,9 @@ annotations: {}
 updateStrategy: {}
 
 # -- Pod labels
-podLabels: {
+podLabels: {}
+
+serviceLabels: {
   giantswarm.io/monitoring: "true"
 }
 

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -39,7 +39,9 @@ annotations: {}
 updateStrategy: {}
 
 # -- Pod labels
-podLabels: {}
+podLabels: {
+  giantswarm.io/monitoring: "true"
+}
 
 # -- Pod annotations
 podAnnotations: {}


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/722

As discussed with @TheoBrigitte and @hervenicol, instead of using servicemonitors right away, we can use labels in the meantime. 
Tested on gauss and seems to be working but will do some testing again later.