### PR TITLE
Enable psp by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable `psp` by default
+
 ### Added
 
 - Added testing guidelines

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -6,6 +6,10 @@ giantswarm:
     serviceLabels: {}
 
 promtail:
+  rbac:
+    # -- Specifies whether a PodSecurityPolicy is to be created
+    pspEnabled: true
+
   image:
     # -- The Docker registry
     registry: docker.io


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/25579

How do we validate ?

Once deployed, check:
- [ ] `promtail psp` created
- [ ] `promtail` pods created
- [ ] no `psp` errors  in the daemonset
