### PR TITLE
add comment in values for cilium

### DIFF
--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -4,6 +4,7 @@ kyvernoPolicyExceptions:
   namespace: giantswarm
 
 ciliumNetworkPolicy:
+  # Must be disabled for imported EKS clusters without cilium as main CNI.
   enabled: true
 
 promtail:


### PR DESCRIPTION
When deploying promtail on an imported EKS cluster without cilium as the main cni, cilium netpols must be disable or they will prevent the app deployment.