### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.4.1] - 2023-12-05
 
 ### Changed
@@ -141,18 +145,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade to promtail 2.2.1
-
-## [0.1.1-alpha3] - 2021-03-16
-
-### Removed
-
-- unsupported and removed in upstream `extra_client_config` and `extra_scrapre_configs` are removed as well
-
-## [0.1.1-alpha2] - 2021-03-15
-
-### Changed
-
-- Upgrade to promtail 2.2.0
 
 ## [0.1.1-alpha] - 2021-03-04
 

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -26,11 +26,11 @@ promtail:
 
   image:
     # -- The Docker registry
-    registry: docker.io
+    registry: gsoci.azurecr.io
     # -- Docker image repository
     repository: giantswarm/promtail
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: null
+    tag:
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
