### PR TITLE
Increase RAM limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set RAM limit to 2x requests, so it has a bit of extra space for pikes and prevent crashes.
+
 ## [1.5.1] - 2024-02-09
 
 ### Changed

--- a/helm/promtail/values.yaml
+++ b/helm/promtail/values.yaml
@@ -46,7 +46,7 @@ promtail:
   resources:
     limits:
       cpu: 200m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 100m
       memory: 128Mi


### PR DESCRIPTION
Towards:
- https://github.com/giantswarm/giantswarm/issues/30232
- https://github.com/giantswarm/giantswarm/issues/29844

Give a bit of extra RAM space to promtail, so it does not crashes directly when reaching its `requests` size