### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Please note that you can run multiple `promtail` instances on the same cluster (
 but it's up to you to provide a reasonable config for them (and ie. avoid
 duplication of scrapes).
 
+## ⚠️  Deprecation notice
+
+On most recent releases we use [Alloy](https://github.com/giantswarm/alloy-app/) to collect logs.
+Promtail is not used anymore, and it is now deprecated.
+
 **Table of Contents:**
 
 - [Install](#install)


### PR DESCRIPTION
Now that new clusters are running Alloy, we probably don't want to keep supporting this app.
Let's add a deprecation notice then archive the repo.